### PR TITLE
Spin 1.4.1

### DIFF
--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -1,0 +1,45 @@
+class Spin < Formula
+  desc "Open-source tool for building and running serverless WebAssembly applications"
+  homepage "https://spin.fermyon.dev/"
+  url "https://github.com/fermyon/spin.git",
+    tag:      "v1.4.1",
+    revision: "e0bd9115fa51399e106681ac1c9ed1afbad1baaa"
+  license "Apache-2.0" => { with: "LLVM-exception" }
+
+  depends_on "cmake" => :build
+  depends_on "rustup-init" => [:build, :test]
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
+  def install
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-qy", "--no-modify-path"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    system "rustup", "target", "add", "wasm32-wasi", "wasm32-unknown-unknown"
+    system "cargo", "install", *std_cargo_args
+
+    # Install default templates and plugins for language tooling and deploying apps to the cloud.
+    # Templates and plugins are installed into `pkgetc/"templates"` and `pkgetc/"plugins"`.
+    system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin", "--upgrade"
+    system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin-python-sdk", "--upgrade"
+    system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin-js-sdk", "--upgrade"
+    system "#{bin}/spin", "plugins", "update"
+    system "#{bin}/spin", "plugins", "install", "js2wasm", "--yes"
+    system "#{bin}/spin", "plugins", "install", "py2wasm", "--yes"
+    system "#{bin}/spin", "plugins", "install", "cloud", "--yes"
+    # Set permissions for local plugins repository
+    chmod_R(0755, pkgetc/"plugins")
+  end
+
+  test do
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-qy", "--no-modify-path"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    system "rustup", "target", "add", "wasm32-wasi", "wasm32-unknown-unknown"
+    system bin/"spin", "new", "http-rust", "test-app", "--accept-defaults"
+    system bin/"spin", "build", "--from", testpath/"test-app/spin.toml"
+    assert_predicate testpath/"test-app/target/wasm32-wasi/release/test_app.wasm", :exist?
+  end
+end

--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -31,7 +31,7 @@ class Spin < Formula
     system "#{bin}/spin", "plugins", "install", "py2wasm", "--yes"
     system "#{bin}/spin", "plugins", "install", "cloud", "--yes"
     # Set permissions for local plugins repository
-    chmod_R(0755, pkgetc/"plugins")
+    chmod_R(0755, etc/"fermyon-spin/plugins")
   end
 
   test do


### PR DESCRIPTION
Add a Formula for Spin, an open-source tool for building and running serverless WebAssembly applications.

Spin currently expects that the [brew formula installs plugins and templates to `$HOMEBREW_PREFIX/etc/fermyon-spin`](https://github.com/fermyon/spin/blob/60011faf310e673f20fc7d5de20f4df8a99374e7/crates/common/src/data_dir.rs#L25). This was chosen instead of `$HOMEBREW_PREFIX/etc/spin` because `homebrew-core` already has a formula named [`spin`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/s/spin.rb) (for another project). Now that we are using our own tap, we could make the directory name just `spin`, but it could potentially conflict with the existent `brew` Spin package if it decides to store data in its `pkgetc` which i doubt will be the case as it isn't now and the formula has not undergone many updates.