### PR TITLE
Remove unnecessary chmod on plugins directory

### DIFF
--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -37,8 +37,6 @@ class Spin < Formula
     system "#{bin}/spin", "plugins", "install", "js2wasm", "--yes"
     system "#{bin}/spin", "plugins", "install", "py2wasm", "--yes"
     system "#{bin}/spin", "plugins", "install", "cloud", "--yes"
-    # Set permissions for local plugins repository
-    chmod_R(0755, etc/"fermyon-spin/plugins")
   end
 
   test do


### PR DESCRIPTION
fixes #9 . Making the `.spin-plugins` repository executable modifies all files in the plugins repository, causing conflicts on `spin plugins update`. Plugins are executable upon installation because we make the plugins executable before packaging them (tar reserves permissions), so no need to explicitly make them executable.