### PR TITLE
ci(*): add workflow to create Spin bump PR on release event; a few script updates

### DIFF
--- a/.github/workflows/bump-spin.yml
+++ b/.github/workflows/bump-spin.yml
@@ -1,0 +1,38 @@
+name: Bump Spin
+
+on:
+  repository_dispatch:
+    types:
+      - spin-release
+
+jobs:
+  create-pr:
+    name: Create PR with Spin Formula bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump Spin Formula
+        shell: bash
+        run: ./scripts/bump-spin-formula.sh ${{ github.event.client_payload.version }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore(spin.rb): bump Spin to ${{ github.event.client_payload.version }}"
+          title: "chore(spin.rb): bump Spin to ${{ github.event.client_payload.version }}"
+          body: Update the Spin formula with ${{ github.event.client_payload.version }}
+          branch: bump-spin-${{ github.event.client_payload.version }}
+          base: main
+          delete-branch: true
+          committer: fermybot <103076628+fermybot@users.noreply.github.com>
+          author: fermybot <103076628+fermybot@users.noreply.github.com>
+          signoff: true

--- a/scripts/bump-spin-formula.sh
+++ b/scripts/bump-spin-formula.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
+set -euo pipefail
 
 VERSION=$1
-FORMULA=${2:-Formula/Spin.rb}
+FORMULA=${2:-Formula/spin.rb}
+
+# -i syntax differs between GNU and Mac sed; this usage is supported by both
+SED_INPLACE='sed -i.bak'
+
+# cleanup
+trap 'rm checksums.txt **/*.bak &>/dev/null' EXIT
 
 usage() {
     echo "Usage: $0 <VERSION> [<FORMULA_PATH>]"
@@ -14,33 +21,27 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-# Ensure the version is prefixed with 'v'
-if [[ $VERSION != v* ]]; then
-    VERSION="v$VERSION"
-fi
-
-# Get the checksum file for the release
-wget -qO checksums.txt "https://github.com/fermyon/spin/releases/download/$VERSION/checksums-$VERSION.txt"
-
-# Check if failed to download the checksum file
-if [ $? -ne 0 ]; then
-    echo "Checksum file not found for version $VERSION"
+# Ensure version is prefixed with 'v' and an 'official' release
+if [[ ! "${VERSION}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+    echo "VERSION doesn't match v[0-9]+.[0-9]+.[0-9]+ and may be a prerelease; skipping."
     exit 1
 fi
 
+# Get the checksum file for the release
+wget -qO checksums.txt "https://github.com/fermyon/spin/releases/download/$VERSION/checksums-$VERSION.txt" || \
+    (echo "Checksum file not found for version $VERSION" && exit 1)
+
 # Remove the 'v' prefix from the version
 ERSION="${VERSION:1}"
-sed -i '' -e "s/version \"[^\"]*\"/version \"$ERSION\"/" $FORMULA
+$SED_INPLACE -e "s/version \"[^\"]*\"/version \"$ERSION\"/" $FORMULA
 # Update the sha256 checksums for each OS/Arch
 while read -r line; do
     filename=$(echo "$line" | awk '{print $2}')
     sha256=$(echo "$line" | awk '{print $1}')
-    os_arch="${filename:12}"
+    os_arch=$(echo ${filename} | sed "s/spin-v${ERSION}-//g")
     if grep -q "$os_arch" $FORMULA; then
-    sed -i '' -E "/url \".*$os_arch\"/ { n; s/sha256 \"[^\"]*\"/sha256 \"$sha256\"/; }" $FORMULA
+        $SED_INPLACE -E "/url \".*$os_arch\"/ { n; s/sha256 \"[^\"]*\"/sha256 \"$sha256\"/; }" $FORMULA
     fi
 done < checksums.txt
-
-rm checksums.txt
 
 echo "Formula updated to version $VERSION with new checksums."


### PR DESCRIPTION
- add the bump-spin.yml workflow to create a PR with versions bumped on a Spin release event (ref https://github.com/fermyon/spin/pull/2428)
- some script updates/tweaks from testing on a GH Linux runner

Tested via https://github.com/vdice/spin/actions/runs/8558657116 and https://github.com/vdice/homebrew-tap/actions/runs/8560792963; see also https://github.com/vdice/homebrew-tap/pull/2