### PR TITLE
Bump version of CI actions to remove deprecated actions/cache@v4

### DIFF
--- a/.github/workflows/bump-spin.yml
+++ b/.github/workflows/bump-spin.yml
@@ -25,7 +25,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore(spin.rb): bump Spin to ${{ github.event.client_payload.version }}"
           title: "chore(spin.rb): bump Spin to ${{ github.event.client_payload.version }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
Looks like the older version of this action used deprecated GH actions that causes CI to fail: https://github.com/fermyon/homebrew-tap/actions/runs/12184774989/job/33989465719?pr=42